### PR TITLE
Updates the peer dependencies to include tailwind3

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "husky install"
   },
   "peerDependencies": {
-    "tailwindcss": ">=2.0.0"
+    "tailwindcss": "2 - 3"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.2",


### PR DESCRIPTION
Currently when installing the package in a tailwind 3 project you get errors in the console and have to install with --force, but it seems to work fine with tailwind@3, so I guess the peer dependencies should just allow version 2 and 3.